### PR TITLE
Upgrade xlsjs to xlsx 0.8.0

### DIFF
--- a/libs/index.js
+++ b/libs/index.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-var xlsjs = require('xlsjs');
+var xlsx = require('xlsx');
 var cvcsv = require('csv');
 
 exports = module.exports = XLS_json;
@@ -24,7 +24,7 @@ function CV(config, callback) {
 }
 
 CV.prototype.load_xls = function(input) {
-  return xlsjs.readFile(input);
+  return xlsx.readFile(input);
 }
 
 CV.prototype.ws = function(wb, target_sheet) {
@@ -33,7 +33,7 @@ CV.prototype.ws = function(wb, target_sheet) {
 }
 
 CV.prototype.csv = function(ws) {
-  return csv_file = xlsjs.utils.make_csv(ws)
+  return csv_file = xlsx.utils.make_csv(ws)
 }
 
 CV.prototype.cvjson = function(csv, output, callback) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/DataGarage/node-xls-json",
   "dependencies": {
-    "xlsjs": "0.7.0",
+    "xlsx": "0.8.0",
     "csv": "~0.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request upgrades the xlsjs 0.7.0 --> xlsx 0.8.0 which enables us to handle both xls and xlsx files.
I've tested this out extensively when mapping many xls and xlsx files to json and it works very well.