### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/DataGarage/node-xls-json",
   "dependencies": {
-    "xlsjs": "0.7.0",
+    "xlsjs": "0.7.5",
     "csv": "~0.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
update version of xlsjs module to solve [TypeError: Cannot set property length of [object Object] which has only a getter].