### PR TITLE
Throw error instead of exiting the process

### DIFF
--- a/libs/index.js
+++ b/libs/index.js
@@ -8,7 +8,7 @@ exports = module.exports = XLS_json;
 
 function XLS_json (config, callback) {
   if(!config.input) {
-    throw new Error("node-xls-json: You did not provide an input file.");
+    callback(new Error("node-xls-json: You did not provide an input file."), null);
   }
 
   var cv = new CV(config, callback);

--- a/libs/index.js
+++ b/libs/index.js
@@ -8,8 +8,7 @@ exports = module.exports = XLS_json;
 
 function XLS_json (config, callback) {
   if(!config.input) {
-    console.error("You miss a input file");
-    process.exit(1);
+    throw new Error("node-xls-json: You did not provide an input file.");
   }
 
   var cv = new CV(config, callback);


### PR DESCRIPTION
I believe this package should not exit the process, but rather throw an error to be handled by the people that use this package.
Otherwise, this may have unintended side effects.